### PR TITLE
Add caching and retry for line item API

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,13 @@ poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --ollama
 run.bat --ticker AAPL,MSFT,NVDA --ollama backtest
 ```
 
+### Rate Limits & Caching
+
+API data is cached in memory for the duration of the process.  The
+`search_line_items` helper now stores results using all query parameters and will
+retry up to three times when the API responds with a 429 status code, waiting
+for the `Retry-After` header when provided.
+
 ## Contributing
 
 1. Fork the repository


### PR DESCRIPTION
## Summary
- cache `search_line_items` results keyed by ticker, requested line items, dates, and limit
- retry line item API calls up to three times when hitting a 429 response
- document caching and retry logic in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684598a34870832ca9b310face98e927